### PR TITLE
update focus cost for explo shot

### DIFF
--- a/Cataclysm/Hunter.lua
+++ b/Cataclysm/Hunter.lua
@@ -2162,6 +2162,10 @@ hunter:RegisterAbilities( {
         spend = function()
             local cost = 50
 
+            if buff.lock_and_load.up then
+                cost = 0
+            end
+            
             if talent.efficiency.rank == 1 then
                 cost = cost - 2
             elseif talent.efficiency.rank == 2 then


### PR DESCRIPTION
Hekili was  not correctly setting 0 focus cost for lock and load procs, this fixes the issue