### PR TITLE
update explosive shot cost function to account for lock and load

### DIFF
--- a/Cataclysm/Hunter.lua
+++ b/Cataclysm/Hunter.lua
@@ -2161,7 +2161,7 @@ hunter:RegisterAbilities( {
 
         spend = function()
             local cost = 50
-                
+
             if talent.efficiency.rank == 1 then
                 cost = cost - 2
             elseif talent.efficiency.rank == 2 then

--- a/Cataclysm/Hunter.lua
+++ b/Cataclysm/Hunter.lua
@@ -2161,7 +2161,7 @@ hunter:RegisterAbilities( {
 
         spend = function()
             local cost = 50
-
+                
             if talent.efficiency.rank == 1 then
                 cost = cost - 2
             elseif talent.efficiency.rank == 2 then
@@ -2172,6 +2172,10 @@ hunter:RegisterAbilities( {
 
             if buff.the_beast_within.up then
                 cost = cost * 0.5
+            end
+
+            if buff.lock_and_load.up then
+                cost = 0
             end
 
             return cost


### PR DESCRIPTION
The explosive shot cost function was not accounting for lock and load. This should fix that and return 0 when a lock and load explosive shot is cast.