### PR TITLE
Cata beta tfb optimization

### DIFF
--- a/Cataclysm/Hunter.lua
+++ b/Cataclysm/Hunter.lua
@@ -2162,6 +2162,10 @@ hunter:RegisterAbilities( {
         spend = function()
             local cost = 50
 
+            if buff.lock_and_load.up then
+                cost = 0
+            end
+            
             if talent.efficiency.rank == 1 then
                 cost = cost - 2
             elseif talent.efficiency.rank == 2 then

--- a/Cataclysm/Hunter.lua
+++ b/Cataclysm/Hunter.lua
@@ -2162,10 +2162,6 @@ hunter:RegisterAbilities( {
         spend = function()
             local cost = 50
 
-            if buff.lock_and_load.up then
-                cost = 0
-            end
-            
             if talent.efficiency.rank == 1 then
                 cost = cost - 2
             elseif talent.efficiency.rank == 2 then

--- a/Cataclysm/Warrior.lua
+++ b/Cataclysm/Warrior.lua
@@ -785,7 +785,7 @@ function GetNextTFB( time, lastApplied )
         return
     end
 
-    local next_possible_tfb = ( (lastApplied or 0 ) == 0 and time ) or ( lastApplied + 6 )
+    local next_possible_tfb = ( (lastApplied or 0 ) == 0 and time ) or ( lastApplied + 5 )
     local next_prediction = 0
     -- Ensure rend_tracker.target is a table
     if type(rend_tracker.target) == "table" then

--- a/Cataclysm/Warrior.lua
+++ b/Cataclysm/Warrior.lua
@@ -715,15 +715,16 @@ spec:RegisterEvent( "COMBAT_LOG_EVENT_UNFILTERED", function()
 
         if application_events[ subtype ] then
 
-            if is_rend then
-                ApplyRend( destGUID, GetTime() )
-            end
             if actionType == 60503 then
                 ApplyTFB( GetTime() )
             end
         end
 
+
         if tick_events[ subtype ] then
+            if is_rend then
+                ApplyRend( destGUID, GetTime() )
+            end
         end
 
         if removal_events[ subtype ] then
@@ -748,7 +749,7 @@ function ApplyRend( destGUID, time )
     else
         RemoveRend( destGUID )
     end
-    for i = time + 3, time + state.debuff.rend.duration, state.debuff.rend.tick_time do
+    for i = time, time + state.debuff.rend.duration, state.debuff.rend.tick_time do
         rend_tracker.target[ destGUID ].ticks[ tostring(i) ] = i
     end
     AssessNextTFB()


### PR DESCRIPTION
![image](https://github.com/Supernuss/hekili/assets/9787500/8d2b736e-7fe8-4c40-bb74-deb4486427ac)


the suggested timing for Taste for Blood is incorrect, and appears to be overshooting by about .5-1.5 seconds. i think this has to do with the REFRESH event caused by mortal strike, but im not quite sure. here is a fix that works, im not sure what the best practices are


changes:

- updating the tick timings based off of tick time, versus application time
- including the initial tick event timing in the table, versus skipping 3 seconds. without removing this, it was causing the prediction to be 3 seconds too late